### PR TITLE
Many small tweaks

### DIFF
--- a/frontend/src/components/contents/presentations/Editor.jsx
+++ b/frontend/src/components/contents/presentations/Editor.jsx
@@ -109,7 +109,7 @@ const Editor = ({
   return (
     <div className="container-fluid">
       <div className="editor">
-        <div className="container-fluid editor-area card-header">
+        <div className="container-fluid editor-area card-header" style={{ paddingRight: 0 }}>
           <div className="input-group input-style">
             <div style={{
               height: '60px',
@@ -119,11 +119,11 @@ const Editor = ({
               lineHeight: '30px',
             }}
             >
-              <spna>
+              <span>
                 Query
                 <br />
                 Editor
-              </spna>
+              </span>
             </div>
             <div className="form-control col-11 editor-code-wrapper">
               <CodeMirror

--- a/frontend/src/components/cypherresult/presentations/CypherResultCytoscape.jsx
+++ b/frontend/src/components/cypherresult/presentations/CypherResultCytoscape.jsx
@@ -359,7 +359,7 @@ const CypherResultCytoscape = forwardRef((props, ref) => {
 
   return (
     <div className="chart-frame-area">
-      <div className="contianer-frame-tab">
+      <div className="container-frame-tab">
         <CypherResultCytoscapeLegend
           onLabelClick={getFooterData}
           isReloading={isReloading}

--- a/frontend/src/components/cypherresult/presentations/CypherResultTable.jsx
+++ b/frontend/src/components/cypherresult/presentations/CypherResultTable.jsx
@@ -75,7 +75,7 @@ const CypherResultTable = ({ data, ...props }) => {
   const { refKey } = props;
   return (
     <div className="legend-area">
-      <div className="contianer-frame-tab">
+      <div className="container-frame-tab">
         <div style={{ width: '80%', color: '#C4C4C4' }}>
           <div className="d-flex nodeLegend">Node:</div>
           <div className="d-flex edgeLegend">Edge:</div>

--- a/frontend/src/components/cytoscape/CytoscapeStyleSheet.js
+++ b/frontend/src/components/cytoscape/CytoscapeStyleSheet.js
@@ -20,7 +20,7 @@ const getLabel = (ele, captionProp) => {
     return `[ :${ele.data('label')} ]`;
   }
   const props = ele.data('properties');
-  if (props[captionProp] === undefined) {
+  if (props === undefined || props[captionProp] === undefined) {
     return '';
   }
   if (ele.isNode()) {
@@ -35,22 +35,38 @@ export const stylesheet = [
   {
     selector: 'node',
     style: {
-      width(ele) { return ele == null ? 55 : ele.data('size'); },
-      height(ele) { return ele == null ? 55 : ele.data('size'); },
+      width(ele) { return ele.data('size') != null ? ele.data('size') : 1; },
+      height(ele) { return ele.data('size') != null ? ele.data('size') : 1; },
       label(ele) {
         const captionProp = ele.data('caption');
         return getLabel(ele, captionProp);
       },
-      'background-color': (ele) => (ele == null ? '#FFF' : ele.data('backgroundColor')),
+      'background-color': (ele) => {
+        let bc;
+        if (ele.data('backgroundColor') != null) {
+          bc = ele.data('backgroundColor');
+        } else {
+          bc = '#FF0000';
+        }
+        return bc;
+      },
       'border-width': '3px',
-      'border-color': (ele) => (ele == null ? '#FFF' : ele.data('borderColor')),
+      'border-color': (ele) => {
+        let bc;
+        if (ele.data('borderColor') != null) {
+          bc = ele.data('borderColor');
+        } else {
+          bc = '#FF0000';
+        }
+        return bc;
+      },
       'border-opacity': 0.6,
       'text-valign': 'center',
       'text-halign': 'center',
-      color(ele) { return ele == null ? '#FFF' : ele.data('fontColor'); },
+      color(ele) { return ele.data('fontColor') != null ? ele.data('fontColor') : '#FFF'; },
       'font-size': '10px',
       'text-wrap': 'ellipsis',
-      'text-max-width': (ele) => (ele == null ? 55 : ele.data('size')),
+      'text-max-width': (ele) => (ele.data('size') != null ? ele.data('size') : 1),
     },
   },
   {
@@ -70,16 +86,32 @@ export const stylesheet = [
   {
     selector: 'edge',
     style: {
-      width(ele) { return ele == null ? 1 : ele.data('size'); },
+      width(ele) { return ele.data('size') != null ? ele.data('size') : 1; },
       label(ele) { const captionProp = ele.data('caption'); return getLabel(ele, captionProp); },
       'text-background-color': '#FFF',
       'text-background-opacity': 1,
       'text-background-padding': '3px',
-      'line-color': (ele) => (ele == null ? '#FFF' : ele.data('backgroundColor')),
-      'target-arrow-color': (ele) => (ele == null ? '#FFF' : ele.data('backgroundColor')),
+      'line-color': (ele) => {
+        let lc;
+        if (ele.data('backgroundColor') != null) {
+          lc = ele.data('backgroundColor');
+        } else {
+          lc = '#FF0000';
+        }
+        return lc;
+      },
+      'target-arrow-color': (ele) => {
+        let tac;
+        if (ele.data('backgroundColor') != null) {
+          tac = ele.data('backgroundColor');
+        } else {
+          tac = '#FF0000';
+        }
+        return tac;
+      },
       'target-arrow-shape': 'triangle',
       'curve-style': 'bezier',
-      color(ele) { return ele == null ? '#FFF' : ele.data('fontColor'); },
+      color(ele) { return ele.data('fontColor') != null ? ele.data('fontColor') : '#FFF'; },
       'font-size': '10px',
       'text-rotation': 'autorotate',
     },
@@ -87,7 +119,7 @@ export const stylesheet = [
   {
     selector: 'edge.highlight',
     style: {
-      width(ele) { return ele == null ? 1 : ele.data('size'); },
+      width(ele) { return ele.data('size') != null ? ele.data('size') : 1; },
       'line-color': '#B2EBF4',
       'target-arrow-color': '#B2EBF4',
       'target-arrow-shape': 'triangle',
@@ -97,7 +129,7 @@ export const stylesheet = [
   {
     selector: 'edge:selected',
     style: {
-      width(ele) { return ele == null ? 1 : ele.data('size'); },
+      width(ele) { return ele.data('size') != null ? ele.data('size') : 1; },
       'line-color': '#B2EBF4',
       'target-arrow-color': '#B2EBF4',
       'target-arrow-shape': 'triangle',

--- a/frontend/src/components/sidebar/presentations/SidebarHome.jsx
+++ b/frontend/src/components/sidebar/presentations/SidebarHome.jsx
@@ -104,10 +104,9 @@ const NodeList = ({ nodes, setCommand }) => {
         <div style={{
           display: 'flex',
           flexWrap: 'wrap',
-          height: '80px',
+          height: 'auto',
           overflowY: 'auto',
           marginTop: '12px',
-          width: '100%',
         }}
         >
           {list}
@@ -179,15 +178,17 @@ const EdgeList = ({ edges, setCommand }) => {
       />
     ));
     return (
-      <div style={{
-        display: 'flex',
-        flexWrap: 'wrap',
-        height: '80px',
-        overflowY: 'auto',
-        marginTop: '12px',
-      }}
-      >
-        {list}
+      <div style={{ width: '100%' }}>
+        <div style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          height: 'auto',
+          overflowY: 'auto',
+          marginTop: '12px',
+        }}
+        >
+          {list}
+        </div>
       </div>
     );
   }
@@ -239,16 +240,17 @@ const PropertyList = ({ propertyKeys, setCommand }) => {
       />
     ));
     return (
-      <div
-        style={{
+      <div style={{ width: '100%' }}>
+        <div style={{
           display: 'flex',
           flexWrap: 'wrap',
-          height: '80px',
+          height: 'auto',
           overflowY: 'auto',
           marginTop: '12px',
         }}
-      >
-        {list}
+        >
+          {list}
+        </div>
       </div>
     );
   }

--- a/frontend/src/lib/cytoscape-cxtmenu-bitnine/cxtmenu.js
+++ b/frontend/src/lib/cytoscape-cxtmenu-bitnine/cxtmenu.js
@@ -23,7 +23,7 @@ const cxtmenu = function (params) {
   let commands = [];
   const c2d = canvas.getContext('2d');
 
-  let r = 100; // defailt radius;
+  let r = 100; // default radius;
   let containerSize = (r + options.activePadding) * 2;
   let activeCommandI;
   let offset;

--- a/frontend/src/static/style.css
+++ b/frontend/src/static/style.css
@@ -236,7 +236,7 @@ a[data-toggle="collapse"] {
     display: none;
 }
 
-.contianer-frame-tab{
+.container-frame-tab{
     display: flex;
     flex-direction: row;
 }


### PR DESCRIPTION
Gets more space for the editor area.

Fix for functions returning null, preventing Cytoscape to function properly.


Gives more vertical space to the label lists.

`className` typo fix.